### PR TITLE
Refactor pmt-builder tool

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,12 @@
+const mempoolJS = require("@mempool/mempool.js");
+
+const fetchBlockTxIds = async (network, hash) => {
+  const { bitcoin: { blocks } } = mempoolJS({
+    hostname: 'mempool.space',
+    network: network // 'testnet' | 'mainnet'
+  });
+
+  return blocks.getBlockTxids({ hash });
+}
+
+module.exports = fetchBlockTxIds;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,3 +4,10 @@
   * @param filteredHash: transaction hash
   */
 export function buildPMT(leaves: string[], filteredHash: string): { totalTX: number, hashes: string[], flags: number, hex: string }
+
+/**
+ *
+ * @param network: testnet or mainnet
+ * @param hash: block hash in hex format
+ */
+export function fetchBlockTxIds(network: string, hash: string): Promise<string[]>

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const fetchBlockTxIds = require("./helper");
+
 let sha256 = require('bitcoinjs-lib').crypto.hash256;
 
 const lpad = (number, length) => number.toString().padStart(length, '0');
@@ -107,4 +109,4 @@ const buildPMT = (leaves, filteredHash) => {
     };
 };
 
-module.exports = { buildPMT };
+module.exports = { buildPMT, fetchBlockTxIds };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/pmt-builder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "PartialMerkleTree builder library",
   "main": "index.js",
   "scripts": {

--- a/tool/pmt-builder.js
+++ b/tool/pmt-builder.js
@@ -1,5 +1,5 @@
-const mempoolJS = require("@mempool/mempool.js");
 const pmtBuilder = require("../index");
+const fetchBlockTxIds = require("../helper");
 
 (async () => {
     try {
@@ -7,14 +7,9 @@ const pmtBuilder = require("../index");
         const hash = process.argv[3];
         const txHash = process.argv[4];
 
-        const { bitcoin: { blocks } } = mempoolJS({
-            hostname: 'mempool.space',
-            network: network // 'testnet' | 'mainnet'
-        });
-    
-        const blockTxids = await blocks.getBlockTxids({ hash });
-
+        const blockTxids = await fetchBlockTxIds(network, hash);
         const resultPmt = pmtBuilder.buildPMT(blockTxids, txHash);
+
         console.log("Block Transactions Ids:", blockTxids);
         console.log("Filtered Hash:", txHash);
         console.log("Result:", resultPmt);


### PR DESCRIPTION
Move the logic fetching the txids of a block using mempool, into a separate function that can be used elsewhere.