### PR TITLE
deps: bump bitcoinjs-lib to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,11 @@
       },
       "devDependencies": {
         "@mempool/mempool.js": "2.3.0",
-        "bitcoinjs-lib": "6.1.7",
+        "bitcoinjs-lib": "7.0.0",
         "merkle-lib": "2.0.10"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -51,7 +54,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -119,11 +121,10 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "dev": true
     },
     "node_modules/bech32": {
       "version": "2.0.0",
@@ -133,31 +134,34 @@
       "license": "MIT"
     },
     "node_modules/bip174": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
-      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
+      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.0.tgz",
+      "integrity": "sha512-2W6dGXFd1KG3Bs90Bzb5+ViCeSKNIYkCUWZ4cvUzUgwnneiNNZ6Sk8twGNcjlesmxC0JyLc/958QycfpvXLg7A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
+        "bip174": "^3.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^0.38.0",
+        "varuint-bitcoin": "^2.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -176,24 +180,22 @@
       "license": "ISC"
     },
     "node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "base-x": "^4.0.0"
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/camelcase": {
@@ -1019,21 +1021,45 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+    "node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.38.0.tgz",
+      "integrity": "sha512-RCJa0fetnzp+h+KN9BdgYOgtsMAG9bfoJ9JSjIhFHobKWVWyzM3jjaeNTdpFK9tQtf3q1sguXeERJ/LcmdFE7w==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/varuint-bitcoin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.1.1"
+        "uint8array-tools": "^0.0.8"
+      }
+    },
+    "node_modules/varuint-bitcoin/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/rsksmart/pmt-builder/issues"
   },
   "homepage": "https://www.rsk.co",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "chai": "6.2.2",
     "mocha": "11.7.5"
@@ -23,7 +26,7 @@
   "types": "./index.d.ts",
   "devDependencies": {
     "@mempool/mempool.js": "2.3.0",
-    "bitcoinjs-lib": "6.1.7",
+    "bitcoinjs-lib": "7.0.0",
     "merkle-lib": "2.0.10"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const pmtBuilder = require('../index');
 const txs3000 = require('./resources/3000-txs');
 const blockWithTargetWitnessTx = require('./resources/btc-block-944725.json');
@@ -6,6 +5,13 @@ const blockWithNonWitnessTargetTx = require('./resources/btc-block-919405.json')
 const btcTestnetBlockWithTargetWitnessTx = require('./resources/btc-testnet-block-4894944.json');
 const btcTestnetBlockWithNonWitnessTargetTx = require('./resources/btc-testnet-block-4706672.json');
 const { fetchBlockWtxidsWithTargetWtxid } = require('../tool/pmt-builder-utils');
+
+let expect;
+
+before(async function loadChai() {
+    const chai = await import('chai');
+    expect = chai.expect;
+});
 
 describe('buildPMT using non-witness target transaction', () => {
     it('should create a valid PMT, block with a single transaction', () => {

--- a/tool/getInformationReadyForRegisterCoinbaseBtcTransaction.js
+++ b/tool/getInformationReadyForRegisterCoinbaseBtcTransaction.js
@@ -80,8 +80,8 @@ const getInformationReadyForRegisterCoinbaseBtcTransaction = async (network, txH
     const hashesWithWitness = txs.map( x => Buffer.from(x.getHash(true)));
     const witnessMerkleTree = merkleLib(hashesWithWitness, bitcoinJs.crypto.hash256);
     // Last element is the root; reverse for registerCoinbase byte order (same as Buffer-based merkle-lib output).
-    const witnessMerkleRootBuf = Buffer.from(witnessMerkleTree[witnessMerkleTree.length - 1]);
-    witnessMerkleRootBuf.reverse();
+    const witnessMerkleRootBuffer = Buffer.from(witnessMerkleTree[witnessMerkleTree.length - 1]);
+    witnessMerkleRootBuffer.reverse();
 
     const {hex: coinbasePmt} = pmtBuilder.buildPMT(blockTxids, coinbaseTxHashWithoutWitness);
 
@@ -89,7 +89,7 @@ const getInformationReadyForRegisterCoinbaseBtcTransaction = async (network, txH
         btcTxSerialized: `0x${coinbaseTxWithoutWitness.toHex()}`,
         btcBlockHash: `0x${blockHash}`,
         pmtSerialized: `0x${coinbasePmt}`,
-        witnessMerkleRoot: `0x${witnessMerkleRootBuf.toString('hex')}`,
+        witnessMerkleRoot: `0x${witnessMerkleRootBuffer.toString('hex')}`,
         witnessReservedValue: `0x${witnessReservedValue}`,
     };
 };

--- a/tool/getInformationReadyForRegisterCoinbaseBtcTransaction.js
+++ b/tool/getInformationReadyForRegisterCoinbaseBtcTransaction.js
@@ -69,18 +69,19 @@ const getInformationReadyForRegisterCoinbaseBtcTransaction = async (network, txH
     const rawCoinbaseBtcTx = await getTransactionWithRetry(transactions, coinbaseTxId);
     const coinbaseTx = bitcoinJs.Transaction.fromHex(rawCoinbaseBtcTx);
 
-    // Hack to get the coinbase transaction hash without witness data
-    const coinbaseTxWithoutWitness = bitcoinJs.Transaction.fromBuffer(coinbaseTx.__toBuffer(undefined, undefined, false));
-    const coinbaseTxHashWithoutWitness = coinbaseTxWithoutWitness.getId();
+    const witnessReservedValue = Buffer.from(coinbaseTx.ins[0].witness[0]).toString('hex');
 
-    const witnessReservedValue = coinbaseTx.ins[0].witness[0].toString('hex');
+    const coinbaseTxWithoutWitness = coinbaseTx.clone();
+    coinbaseTxWithoutWitness.stripWitnesses();
+    const coinbaseTxHashWithoutWitness = coinbaseTxWithoutWitness.getId();
     const txs = await getAllTxs(transactions, blockTxids);
 
     // Calculate witnessRoot
     const hashesWithWitness = txs.map( x => Buffer.from(x.getHash(true)));
     const witnessMerkleTree = merkleLib(hashesWithWitness, bitcoinJs.crypto.hash256);
-    // Get witness merkleRoot from witnessMerkleTree. This is equal to the last element in witnessMerkleTree array
-    const witnessMerkleRoot = witnessMerkleTree[witnessMerkleTree.length-1].reverse();
+    // Last element is the root; reverse for registerCoinbase byte order (same as Buffer-based merkle-lib output).
+    const witnessMerkleRootBuf = Buffer.from(witnessMerkleTree[witnessMerkleTree.length - 1]);
+    witnessMerkleRootBuf.reverse();
 
     const {hex: coinbasePmt} = pmtBuilder.buildPMT(blockTxids, coinbaseTxHashWithoutWitness);
 
@@ -88,7 +89,7 @@ const getInformationReadyForRegisterCoinbaseBtcTransaction = async (network, txH
         btcTxSerialized: `0x${coinbaseTxWithoutWitness.toHex()}`,
         btcBlockHash: `0x${blockHash}`,
         pmtSerialized: `0x${coinbasePmt}`,
-        witnessMerkleRoot: `0x${witnessMerkleRoot.toString('hex')}`,
+        witnessMerkleRoot: `0x${witnessMerkleRootBuf.toString('hex')}`,
         witnessReservedValue: `0x${witnessReservedValue}`,
     };
 };

--- a/tool/pmt-builder-utils.js
+++ b/tool/pmt-builder-utils.js
@@ -39,8 +39,9 @@ const fetchBlockWtxidsWithTargetWtxid = async (transactionsClient, blockTxids, t
 const getWtxid = async (transactionsClient, txid) => {
     const rawTx = await getTransactionWithRetry(transactionsClient, txid);
     const tx = bitcoin.Transaction.fromHex(rawTx);
-    const wtxid = tx.getHash(true).reverse().toString('hex');
-    return wtxid;
+    const hashBytes = Buffer.from(tx.getHash(true));
+    hashBytes.reverse();
+    return hashBytes.toString('hex');
 };
 
 /**


### PR DESCRIPTION
Update dev tooling and tests for breaking Buffer→Uint8Array changes, fix witness merkle root hex encoding, and declare engines.node >= 18.

## Validations

1. Ran tests
2. Ran `getInformationReadyForRegisterBtcTransaction.js` and got expected results (except for expected difference in the pmt).
3. Ran `getInformationReadyForRegisterCoinbaseBtcTransaction.js` and got expected results.